### PR TITLE
Fix fetching PHOTO elements, add line folding

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -112,26 +112,35 @@ class VCard
     /**
      * Add a photo or logo (depending on property name)
      *
-     * @return void
+     * @return boolean
      * @param  string $property LOGO|PHOTO
      * @param  string $url image url or filename
-     * @param  bool   $encode to integrate / encode or not the file
+     * @param  bool $encode to integrate / encode or not the file
      */
     private function addMedia($property, $url, $encode = false)
     {
         if ($encode) {
             $value = file_get_contents($url);
-
-            $finfo = finfo_open(FILEINFO_MIME);
-            @$mime = finfo_file($finfo, $url);
-            
+            if (!$value) {
+                return false; //Nothing returned from URL
+            }
+            if (!function_exists('getimagesizefromstring')) { //Introduced in PHP 5.4
+                $imginfo = getimagesize('data://application/octet-stream;base64,' . base64_encode($value));
+            } else {
+                $imginfo = getimagesizefromstring($value);
+            }
+            if (array_key_exists('mime', $imginfo)) {
+                $type = strtoupper(str_replace('image/', '', $imginfo['mime']));
+            } else {
+                return false; //Returned data doesn't have a MIME type
+            }
             $value = base64_encode($value);
-            $property .= ";ENCODING=b;TYPE=" . strtoupper(str_replace('image/', '', $mime));
+            $property .= ";ENCODING=b;TYPE=" . $type;
         } else {
             $value = $url;
         }
-        
         $this->setProperty($property, $value);
+        return true;
     }
 
     /**
@@ -235,7 +244,7 @@ class VCard
         // loop all properties
         foreach ($this->properties as $key => $value) {
             // add to string
-            $string .= $key . ':' . $value . "\r\n";
+            $string .= $this->fold($key . ':' . $value . "\r\n");
         }
 
         // add to string
@@ -298,9 +307,7 @@ class VCard
     }
 
     /**
-     * Download
-     *
-     * @return header will push file to your browser
+     * Download a vcard or vcal file to the browser.
      */
     public function download()
     {
@@ -418,5 +425,20 @@ class VCard
     private function setProperty($key, $value)
     {
         $this->properties[$key] = $this->decode($value);
+    }
+
+    /**
+     * Fold a line according to RFC2425 section 5.8.1.
+     * @link http://tools.ietf.org/html/rfc2425#section-5.8.1
+     * @param string $text
+     * @return mixed
+     */
+    protected function fold($text)
+    {
+        if (strlen($text) <= 75) {
+            return $text;
+        }
+        //Split, wrap and trim trailing separator
+        return substr(chunk_split($text, 73, "\r\n "), 0, -3);
     }
 }


### PR DESCRIPTION
I ran into some problems with adding PHOTO type elements. The `finfo*` functions just didn't work for me (in PHP 5.6.5; `finfo_file` just returned false), so I rewrote the `addMedia` method to use `getimagesize` instead. The finfo call was also fetching the media item a second time, when it had already been fetched by the `file_get_contents` call beforehand, so this should be twice as fast. `getimagesize` needs a local path, so I write the fetched file to the system temp dir, read it back, and delete it afterwards.

There was also no error checking in this function, so I made it return a boolean to indicate success or not.

I noticed that the resulting vcards did not use line folding as per RFC 2425 to limit line length to 75 chars, so I added a protected method to do that. This is not UTF-8 safe, however, the spec says that unfolding should occur before anything else, in which case UTF-8 chars will be reconstructed before they are interpreted.

The resulting vcards now load successfully, including images, into the OS X Contacts app, and they look more like the vcards produced when exporting from Contacts too.