### PR TITLE
Added charsetString variable

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -59,6 +59,13 @@ class VCard
     public $charset = 'utf-8';
 
     /**
+     * Charset string
+     *
+     * @var string
+     */
+    private $charsetString = '';
+
+    /**
      * Add address
      *
      * @param  string [optional] $name
@@ -89,7 +96,7 @@ class VCard
         // set property
         $this->setProperty(
             'address',
-            'ADR' . (($type != '') ? ';' . $type : ''),
+            'ADR' . (($type != '') ? ';' . $type : '') . $this->getCharsetString(),
             $value
         );
 
@@ -123,7 +130,7 @@ class VCard
     {
         $this->setProperty(
             'company',
-            'ORG',
+            'ORG' . $this->getCharsetString(),
             $company
         );
 
@@ -165,7 +172,7 @@ class VCard
     {
         $this->setProperty(
             'jobtitle',
-            'TITLE',
+            'TITLE' . $this->getCharsetString(),
             $jobtitle
         );
 
@@ -246,7 +253,7 @@ class VCard
         $property = $lastName . ';' . $firstName . ';' . $additional . ';' . $prefix . ';' . $suffix;
         $this->setProperty(
             'name',
-            'N',
+            'N' . $this->getCharsetString(),
             $property
         );
 
@@ -255,7 +262,7 @@ class VCard
             // set property
             $this->setProperty(
                 'fullname',
-                'FN',
+                'FN' . $this->getCharsetString(),
                 trim(implode(' ', $values))
             );
         }
@@ -273,7 +280,7 @@ class VCard
     {
         $this->setProperty(
             'note',
-            'NOTE',
+            'NOTE' . $this->getCharsetString(),
             $note
         );
 
@@ -488,6 +495,16 @@ class VCard
     }
 
     /**
+     * Get charset string
+     *
+     * @return string
+     */
+    public function getCharsetString()
+    {
+        return $this->charsetString;
+    }
+
+    /**
      * Get content type
      *
      * @return string
@@ -638,6 +655,19 @@ class VCard
     public function setCharset($charset)
     {
         $this->charset = $charset;
+    }
+
+    /**
+     * Set charset string
+     *
+     * @param  string $charset The charset for one property
+     * @return void
+     */
+    public function setCharsetString($charset)
+    {
+        if ($charset) {
+            $this->charsetString = ';CHARSET=' . $charset;
+        }
     }
 
     /**

--- a/src/VCard.php
+++ b/src/VCard.php
@@ -59,13 +59,6 @@ class VCard
     public $charset = 'utf-8';
 
     /**
-     * Charset string
-     *
-     * @var string
-     */
-    private $charsetString = '';
-
-    /**
      * Add address
      *
      * @param  string [optional] $name
@@ -501,7 +494,11 @@ class VCard
      */
     public function getCharsetString()
     {
-        return $this->charsetString;
+        $charsetString = '';
+        if ($this->charset == 'utf-8') {
+            $charsetString = ';CHARSET=' . $this->charset;
+        }
+        return $charsetString;
     }
 
     /**
@@ -655,19 +652,6 @@ class VCard
     public function setCharset($charset)
     {
         $this->charset = $charset;
-    }
-
-    /**
-     * Set charset string
-     *
-     * @param  string $charset The charset for one property
-     * @return void
-     */
-    public function setCharsetString($charset)
-    {
-        if ($charset) {
-            $this->charsetString = ';CHARSET=' . $charset;
-        }
     }
 
     /**


### PR DESCRIPTION
It seems to be the only option to generate vCards for Windows (I have done some tests with 7-10 and Outlook) with UTF-8 charset strings by adding ;CHARSET=utf-8 to each line that could contain utf-8 signs. It is not enough to set only the mime header, as it should be according to https://tools.ietf.org/html/rfc6350.

The charsetString variable is empty by default to stay valid with the RFC, but it could be set with setCharsetString to support Windows vCard import implementations.