### PR TITLE
Issue #69: Handle grouped properties

### DIFF
--- a/tests/VCardParserTest.php
+++ b/tests/VCardParserTest.php
@@ -153,17 +153,17 @@ class VCardParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($parser->getCardAtIndex(0)->url['PREF;WORK'][0], 'http://work1.example.com');
         $this->assertEquals($parser->getCardAtIndex(0)->url['PREF;WORK'][1], 'http://work2.example.com');
     }
-    
+
     public function testNote()
     {
         $vcard = new VCard();
         $vcard->addNote('This is a testnote');
         $parser = new VCardParser($vcard->buildVCard());
-        
+
         $vcardMultiline = new VCard();
         $vcardMultiline->addNote("This is a multiline note\nNew line content!\r\nLine 2");
         $parserMultiline = new VCardParser($vcardMultiline->buildVCard());
-        
+
         $this->assertEquals($parser->getCardAtIndex(0)->note, 'This is a testnote');
         $this->assertEquals(nl2br($parserMultiline->getCardAtIndex(0)->note), nl2br("This is a multiline note" . PHP_EOL . "New line content!" . PHP_EOL . "Line 2"));
     }
@@ -239,6 +239,10 @@ class VCardParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($cards[0]->firstname, "Wouter");
         $this->assertEquals($cards[0]->lastname, "Admiraal");
         $this->assertEquals($cards[0]->fullname, "Wouter Admiraal");
+        // Check the parsing of grouped items as well, which are present in the
+        // example file.
+        $this->assertEquals($cards[0]->url['default'][0], 'http://example.com');
+        $this->assertEquals($cards[0]->email['INTERNET'][0], 'site@example.com');
     }
 
     /**

--- a/tests/example.vcf
+++ b/tests/example.vcf
@@ -3,4 +3,8 @@ VERSION:3.0
 REV:2016-05-30T10:36:13Z
 N;CHARSET=utf-8:Admiraal;Wouter;;;
 FN;CHARSET=utf-8:Wouter Admiraal
+item1.EMAIL;type=INTERNET:site@example.com
+item1.X-ABLabel:$!<Email>!$
+item2.URL:http://example.com
+item2.X-ABLabel:$!<Home>!$
 END:VCARD


### PR DESCRIPTION
As per RFC, properties can be grouped together by prefixing them with
an arbitrary, alphanumeric value, followed by a full stop (.). Add
support for this in the VCardParser class, and add unit tests
accordingly.
