### PR TITLE
Replace finfo_...() calls with mime_content_type() to avoid magic/int… 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # VCard PHP class
-[![Latest Stable Version](http://img.shields.io/packagist/v/jeroendesloovere/vcard.svg)](https://packagist.org/packages/jeroendesloovere/vcard)
+[![Latest Stable Version](http://img.shields.io/packagist/v/jeroendesloovere/vcard.svg)](https://packagist.org/packages/anakadote/vcard)
 [![License](http://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/jeroendesloovere/vcard/blob/master/LICENSE)
-[![Build Status](https://travis-ci.org/jeroendesloovere/vcard.svg?branch=master)](https://travis-ci.org/jeroendesloovere/vcard)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/jeroendesloovere/vcard/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/jeroendesloovere/vcard/?branch=master)
 
 This VCard PHP class can generate a vCard with some data. When using an iOS device < iOS 8 it will export as a .ics file because iOS devices don't support the default .vcf files.
 
@@ -13,7 +11,7 @@ This VCard PHP class can generate a vCard with some data. When using an iOS devi
 ``` json
 {
     "require": {
-        "jeroendesloovere/vcard": "1.2.*"
+        "anakadote/vcard": "1.2.*"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "jeroendesloovere/vcard",
+    "name": "anakadote/vcard",
     "type": "library",
     "description": "This VCard PHP class can generate a vCard with some data. When using an iOS device it will export as a .ics file because iOS devices don't support the default .vcf files.",
     "keywords": ["vcard", "generator", ".vcf", "php"],
-    "homepage": "https://github.com/jeroendesloovere/vcard",
+    "homepage": "https://github.com/anakadote/vcard",
     "license": "MIT",
     "authors": [
         {

--- a/src/VCard.php
+++ b/src/VCard.php
@@ -190,10 +190,8 @@ class VCard
             }
 
             $value = base64_encode($value);
-
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            $mimetype = finfo_file($finfo, 'data://application/octet-stream;base64,' . $value);
-            finfo_close($finfo);
+            
+            $mimetype = mime_content_type($url);
 
             if (preg_match('/^image\//', $mimetype) !== 1) {
                 throw new VCardMediaException('Returned data aren\'t an image.');


### PR DESCRIPTION
Replace finfo_...() calls with mime_content_type() to avoid magic/internal database errors.

The error/warning: Warning: finfo::file(): Failed identify data 0:no magic files loaded. (on line 195)

As an added bonus we're replacing three lines of code with just one.

There is an existing bug report here: https://bugs.php.net/bug.php?id=69773
