### PR TITLE
Implemented 'ROLE Type' following section '3.5.2 ROLE Type Definition' of rfc2426

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $vcard->addName($lastname, $firstname, $additional, $prefix, $suffix);
 // add work data
 $vcard->addCompany('Siesqo');
 $vcard->addJobtitle('Web Developer');
+$vcard->addRole('Data Protection Officer');
 $vcard->addEmail('info@jeroendesloovere.be');
 $vcard->addPhoneNumber(1234121212, 'PREF;WORK');
 $vcard->addPhoneNumber(123456789, 'WORK');

--- a/src/VCard.php
+++ b/src/VCard.php
@@ -173,6 +173,23 @@ class VCard
     }
 
     /**
+     * Add role
+     *
+     * @param  string $role The role for the person.
+     * @return $this
+     */
+    public function addRole($role)
+    {
+        $this->setProperty(
+            'role',
+            'ROLE' . $this->getCharsetString(),
+            $role
+        );
+
+        return $this;
+    }
+
+    /**
      * Add a photo or logo (depending on property name)
      *
      * @param  string              $property LOGO|PHOTO

--- a/tests/VCardTest.php
+++ b/tests/VCardTest.php
@@ -104,6 +104,11 @@ class VCardTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->vcard, $this->vcard->addJobtitle(''));
     }
 
+    public function testAddRole()
+    {
+        $this->assertEquals($this->vcard, $this->vcard->addRole(''));
+    }
+
     public function testAddName()
     {
         $this->assertEquals($this->vcard, $this->vcard->addName(''));
@@ -251,6 +256,17 @@ class VCardTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($this->vcard, $this->vcard->addJobtitle('1'));
         $this->assertEquals($this->vcard, $this->vcard->addJobtitle('2'));
+    }
+
+    /**
+     * Test multiple roles
+     *
+     * @expectedException JeroenDesloovere\VCard\Exception
+     */
+    public function testMultipleRoles()
+    {
+        $this->assertEquals($this->vcard, $this->vcard->addRole('1'));
+        $this->assertEquals($this->vcard, $this->vcard->addRole('2'));
     }
 
     /**


### PR DESCRIPTION
I implemented ROLE Type' following section '3.5.2 ROLE Type Definition' of  [rfc2426](http://www.ietf.org/rfc/rfc2426.txt)

> 3.5.2
> 
>  ROLE Type Definition
> 
>    To: ietf-mime-directory@imc.org
> 
>    Subject: Registration of text/directory MIME type ROLE
> 
>    Type name: ROLE
> 
>    Type purpose: To specify information concerning the role, occupation,
>    or business category of the object the vCard represents.
> 
>    Type encoding: 8bit
> 
>    Type value: A single text value.
> 
>    Type special notes: This type is based on the X.520 Business Category
>    explanatory attribute. This property is included as an organizational
>    type to avoid confusion with the semantics of the TITLE type and
>    incorrect usage of that type when the semantics of this type is
>    intended.
> 
>    Type example:
> 
>         ROLE:Programmer