### PR TITLE
Save Path for saving vcards on disk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ $vcard->addPhoto(__DIR__ . '/landscape.jpeg');
 
 // return vcard as a download
 return $vcard->download();
+
+// save vcard on disk
+//$vcard->setSavePath('/path/to/directory');
+//$vcard->save();
+
 ```
 
 > [View all examples](/examples/example.php) or check [the VCard class](/src/VCard.php).

--- a/src/VCard.php
+++ b/src/VCard.php
@@ -796,7 +796,7 @@ class VCard
             throw new Exception('Output directory does not exist.');
         }
 
-        // Add trailing directory separator the the save path
+        // Add trailing directory separator the save path
         if (substr($savePath, -1) != DIRECTORY_SEPARATOR) {
             $savePath .= DIRECTORY_SEPARATOR;
         }

--- a/src/VCard.php
+++ b/src/VCard.php
@@ -33,6 +33,13 @@ class VCard
     private $filename;
 
     /**
+     * Save Path
+     *
+     * @var string
+     */
+    private $savePath = null;
+
+    /**
      * Multiple properties for element allowed
      *
      * @var array
@@ -526,7 +533,7 @@ class VCard
         // split, wrap and trim trailing separator
         return substr(chunk_split($text, 73, "\r\n "), 0, -3);
     }
-    
+
     /**
      * Escape newline characters according to RFC2425 section 5.8.4.
      *
@@ -538,7 +545,7 @@ class VCard
     {
         $text = str_replace("\r\n", "\\n", $text);
         $text = str_replace("\n", "\\n", $text);
-        
+
         return $text;
     }
 
@@ -718,6 +725,11 @@ class VCard
     {
         $file = $this->getFilename() . '.' . $this->getFileExtension();
 
+        // Add save path if given
+        if (null !== $this->savePath) {
+            $file = $this->savePath . $file;
+        }
+
         file_put_contents(
             $file,
             $this->getOutput()
@@ -770,6 +782,26 @@ class VCard
         // overwrite filename or add to filename using a prefix in between
         $this->filename = ($overwrite) ?
             $value : $this->filename . $separator . $value;
+    }
+
+    /**
+     * Set the save path directory
+     *
+     * @param  string $savePath Save Path
+     * @throws Exception
+     */
+    public function setSavePath($savePath)
+    {
+        if (!is_dir($savePath)) {
+            throw new Exception('Output directory does not exist.');
+        }
+
+        // Add trailing directory separator the the save path
+        if (substr($savePath, -1) != DIRECTORY_SEPARATOR) {
+            $savePath .= DIRECTORY_SEPARATOR;
+        }
+
+        $this->savePath = $savePath;
     }
 
     /**


### PR DESCRIPTION
It is currently not possible to specify a save path where the VCard class should save the vcards. It always saves them in the directory the script is running. 

This PR adds the possibility to specify the save path which is then used for saving the vcard on disk.

Also, Travis should run the test against PHP 7.0 as well.