### PR TITLE
fixed content length. mb_strlen counts multibyte characters as one. s…

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -646,7 +646,7 @@ class VCard
     {
         $contentType = $this->getContentType() . '; charset=' . $this->getCharset();
         $contentDisposition = 'attachment; filename=' . $this->getFilename() . '.' . $this->getFileExtension();
-        $contentLength = mb_strlen($this->getOutput(), $this->getCharset());
+        $contentLength = strlen($this->getOutput());
         $connection = 'close';
 
         if ((bool)$asAssociative) {


### PR DESCRIPTION
The content length is wrong with mb_strlen if there are mutlibyte characters in the content. The [documentation](http://php.net/manual/en/function.mb-strlen.php) says that mb_strlen counts multibyte characters as one. This pull request replaces the mb_strlen function by strlen.