### PR TITLE
Support for redirected media urls

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -214,6 +214,9 @@ class VCard
 
             if (array_key_exists('Content-Type', $headers)) {
                 $mimeType = $headers['Content-Type'];
+                if (is_array($mimeType)) {
+                    $mimeType = end($mimeType);
+                }
             }
         } else {
             //Local file, so inspect it directly


### PR DESCRIPTION
When a request is redirected, `get_headers()` returns the headers for all the responses in the request chain. When a header is specified in multiple responses, `get_headers()` returns the header value as an array of strings instead of a single string.

In effect, if the media url is redirected once, `$mediaType` could for example look like this: `[0 => "text/html; charset=UTF-8", 1 => "image/jpeg"]`. Hence the last element of the array should be used as the media type.