### PR TITLE
Add media content

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -256,6 +256,36 @@ class VCard
     }
 
     /**
+     * Add a photo or logo (depending on property name)
+     *
+     * @param string $property LOGO|PHOTO
+     * @param string $content image content
+     * @param string $element The name of the element to set
+     */
+    private function addMediaContent($property, $content, $element)
+    {
+        $finfo = new \finfo();
+        $mimeType = $finfo->buffer($content, FILEINFO_MIME_TYPE);
+
+        if (strpos($mimeType, ';') !== false) {
+            $mimeType = strstr($mimeType, ';', true);
+        }
+        if (!is_string($mimeType) || substr($mimeType, 0, 6) !== 'image/') {
+            throw VCardException::invalidImage();
+        }
+        $fileType = strtoupper(substr($mimeType, 6));
+
+        $content = base64_encode($content);
+        $property .= ";ENCODING=b;TYPE=" . $fileType;
+
+        $this->setProperty(
+            $element,
+            $property,
+            $content
+        );
+    }
+
+    /**
      * Add name
      *
      * @param  string [optional] $lastName
@@ -380,6 +410,23 @@ class VCard
     }
 
     /**
+     * Add Logo content
+     *
+     * @param  string $content image content
+     * @return $this
+     */
+    public function addLogoContent($content)
+    {
+        $this->addMediaContent(
+            'LOGO',
+            $content,
+            'logo'
+        );
+
+        return $this;
+    }
+
+    /**
      * Add Photo
      *
      * @param  string $url image url or filename
@@ -392,6 +439,23 @@ class VCard
             'PHOTO',
             $url,
             $include,
+            'photo'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add Photo content
+     *
+     * @param  string $content image content
+     * @return $this
+     */
+    public function addPhotoContent($content)
+    {
+        $this->addMediaContent(
+            'PHOTO',
+            $content,
             'photo'
         );
 

--- a/tests/VCardTest.php
+++ b/tests/VCardTest.php
@@ -160,6 +160,24 @@ class VCardTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAddPhotoContentWithJpgPhoto()
+    {
+        $return = $this->vcard->addPhotoContent(file_get_contents(__DIR__ . '/image.jpg'));
+
+        $this->assertEquals($this->vcard, $return);
+    }
+
+    /**
+     * Test adding empty photo
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessage Returned data is not an image.
+     */
+    public function testAddPhotoContentWithEmptyContent()
+    {
+        $this->vcard->addPhotoContent('');
+    }
+
     public function testAddLogoWithJpgImage()
     {
         $return = $this->vcard->addLogo(__DIR__ . '/image.jpg', true);
@@ -172,6 +190,24 @@ class VCardTest extends \PHPUnit_Framework_TestCase
         $return = $this->vcard->addLogo(__DIR__ . '/image.jpg', false);
 
         $this->assertEquals($this->vcard, $return);
+    }
+
+    public function testAddLogoContentWithJpgImage()
+    {
+        $return = $this->vcard->addLogoContent(file_get_contents(__DIR__ . '/image.jpg'));
+
+        $this->assertEquals($this->vcard, $return);
+    }
+
+    /**
+     * Test adding empty photo
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessage Returned data is not an image.
+     */
+    public function testAddLogoContentWithEmptyContent()
+    {
+        $this->vcard->addLogoContent('');
     }
 
     public function testAddUrl()


### PR DESCRIPTION
This pull request makes it possible to add photo or logo by specifying the image content, in addition to the present possibilities of file path and url. This is useful for example if the image content is stored in a database or a remote file system, such as AWS S3 or Microsoft Azure.