### PR TITLE
Always return charset for strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jeroendesloovere/vcard",
+    "name": "christianruhstaller/vcard",
     "type": "library",
     "description": "This VCard PHP class can generate a vCard with some data. When using an iOS device it will export as a .ics file because iOS devices don't support the default .vcf files.",
     "keywords": ["vcard", "generator", ".vcf", "php"],

--- a/src/VCard.php
+++ b/src/VCard.php
@@ -674,12 +674,7 @@ class VCard
      */
     public function getCharsetString()
     {
-        $charsetString = '';
-        if ($this->charset == 'utf-8') {
-            $charsetString = ';CHARSET=' . $this->charset;
-        }
-
-        return $charsetString;
+        return ';CHARSET=' . $this->charset;
     }
 
     /**


### PR DESCRIPTION
This will fix issues with the encoding on mac and windows.