### PR TITLE
fix download function vCard 4.0 

### DIFF
--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -36,8 +36,8 @@ final class Formatter
 
     public function download(): void
     {
-        foreach ($this->getHeaders() as $header) {
-            header($header);
+        foreach ($this->getHeaders() as $key => $value) {
+            header(sprintf("%s: %s", $key, $value));
         }
 
         echo $this->getContent();


### PR DESCRIPTION
header need a $key and $value separated by a :

at Vcard3 there was a switch between Associative Array and a non-Associative Array, now there is only the Associative Array. but with this fix this doesent matter