### PR TITLE
add Role Property to vCard 4.0

### DIFF
--- a/src/Formatter/Property/RoleFormatter.php
+++ b/src/Formatter/Property/RoleFormatter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenDesloovere\VCard\Formatter\Property;
+
+final class RoleFormatter extends SimpleNodeFormatter
+{
+
+}

--- a/src/Parser/Property/RoleParser.php
+++ b/src/Parser/Property/RoleParser.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenDesloovere\VCard\Parser\Property;
+
+use JeroenDesloovere\VCard\Property\Role;
+use JeroenDesloovere\VCard\Property\NodeInterface;
+
+final class RoleParser implements NodeParserInterface
+{
+    public function parseLine(string $value, array $parameters = []): NodeInterface
+    {
+        return new Role($value);
+    }
+}

--- a/src/Property/Role.php
+++ b/src/Property/Role.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenDesloovere\VCard\Property;
+
+use JeroenDesloovere\VCard\Formatter\Property\RoleFormatter;
+use JeroenDesloovere\VCard\Formatter\Property\NodeFormatterInterface;
+use JeroenDesloovere\VCard\Parser\Property\RoleParser;
+use JeroenDesloovere\VCard\Parser\Property\NodeParserInterface;
+use JeroenDesloovere\VCard\Property\Value\StringValue;
+
+final class Role extends StringValue implements PropertyInterface, SimpleNodeInterface
+{
+    public function getFormatter(): NodeFormatterInterface
+    {
+        return new RoleFormatter($this);
+    }
+
+    public static function getNode(): string
+    {
+        return 'ROLE';
+    }
+
+    public static function getParser(): NodeParserInterface
+    {
+        return new RoleParser();
+    }
+
+    public function isAllowedMultipleTimes(): bool
+    {
+        return false;
+    }
+}

--- a/src/VCard.php
+++ b/src/VCard.php
@@ -25,6 +25,7 @@ use JeroenDesloovere\VCard\Property\Photo;
 use JeroenDesloovere\VCard\Property\PropertyInterface;
 use JeroenDesloovere\VCard\Property\Telephone;
 use JeroenDesloovere\VCard\Property\Title;
+use JeroenDesloovere\VCard\Property\Role;
 
 final class VCard
 {
@@ -42,6 +43,7 @@ final class VCard
         Gender::class,
         Nickname::class,
         Title::class,
+        Role::class,
         Birthdate::class,
         Anniversary::class,
         Email::class,

--- a/tests/VCardTest.php
+++ b/tests/VCardTest.php
@@ -23,6 +23,7 @@ use JeroenDesloovere\VCard\Property\Parameter\Type;
 use JeroenDesloovere\VCard\Property\Photo;
 use JeroenDesloovere\VCard\Property\Telephone;
 use JeroenDesloovere\VCard\Property\Title;
+use JeroenDesloovere\VCard\Property\Role;
 use JeroenDesloovere\VCard\VCard;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
@@ -80,6 +81,7 @@ final class VCardTest extends TestCase
     {
         $this->thirdVCard = (new VCard(Kind::organization()))
             ->add(new Title('Apple'))
+            ->add(new Role('Fruit'))
             ->add(new Photo(__DIR__ . '/assets/landscape.jpeg'))
             ->add(new Logo(__DIR__ . '/assets/landscape.jpeg'))
             ->add(new Telephone('+32 486 00 00 00'));
@@ -186,8 +188,9 @@ final class VCardTest extends TestCase
         $this->assertCount(1, $this->secondVCard->getProperties(Name::class));
         $this->assertCount(1, $this->secondVCard->getProperties(Address::class));
 
-        $this->assertCount(4, $this->thirdVCard->getProperties());
+        $this->assertCount(5, $this->thirdVCard->getProperties());
         $this->assertCount(1, $this->thirdVCard->getProperties(Title::class));
+        $this->assertCount(1, $this->thirdVCard->getProperties(Role::class));
         $this->assertCount(1, $this->thirdVCard->getProperties(Photo::class));
         $this->assertCount(1, $this->thirdVCard->getProperties(Logo::class));
         $this->assertCount(1, $this->thirdVCard->getProperties(Telephone::class));


### PR DESCRIPTION
this add the Role Property to the vCard 4.0
everything is fine, besides the fact that the field/property is not really useful ;-)
because it is neither displayed in Outlook nor AppleContact on the Mac, for example.
On Windows Outlook it was added on Details Tab inside the "Professional" Field

i add this Property to the thirdVCard inside the test