### PR TITLE
allow extention of setProperty(), add socialmedia option

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -47,7 +47,8 @@ class VCard
         'address',
         'phoneNumber',
         'url',
-        'label'
+        'label',
+        'socialmedia'
     ];
 
     /**
@@ -156,7 +157,7 @@ class VCard
     {
         $this->setProperty(
             'email',
-            'EMAIL;INTERNET' . (($type != '') ? ';' . $type : ''),
+            'EMAIL;type=INTERNET;' . (($type != '') ? ';' . $type : ''),
             $address
         );
 
@@ -211,6 +212,25 @@ class VCard
             'role',
             'ROLE' . $this->getCharsetString(),
             $role
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add socialMedia
+     *
+     * @param  string $type The type of social media.
+     * @param  string $addr The address of the social media platform.
+     * @return $this
+     */
+    public function addSocial($type = '', $url)
+    {
+
+        $this->setProperty(
+            'socialmedia',
+            'X-SOCIALPROFILE;type=' . (($type != '') ? $type : '' ),
+            $url
         );
 
         return $this;
@@ -643,7 +663,7 @@ class VCard
     /**
      * multibyte word chunk split
      * @link http://php.net/manual/en/function.chunk-split.php#107711
-     * 
+     *
      * @param  string  $body     The string to be chunked.
      * @param  integer $chunklen The chunk length.
      * @param  string  $end      The line ending sequence.
@@ -935,7 +955,7 @@ class VCard
      * @param  string $value
      * @throws VCardException
      */
-    private function setProperty($element, $key, $value)
+    protected function setProperty($element, $key, $value)
     {
         if (!in_array($element, $this->multiplePropertiesForElementAllowed)
             && isset($this->definedElements[$element])

--- a/src/VCardParser.php
+++ b/src/VCardParser.php
@@ -245,6 +245,13 @@ class VCardParser implements Iterator
                         $key = !empty($types) ? implode(';', $types) : 'default';
                         $cardData->url[$key][] = $value;
                         break;
+                    case 'SOCIALMEDIA':
+                        if (!isset($cardData->socialmedia)) {
+                            $cardData->socialmedia = [];
+                        }
+                        $key = !empty($types) ? implode(';', $types) : 'default';
+                        $cardData->socialmedia[$key][] = $value;
+                        break;
                     case 'TITLE':
                         $cardData->title = $value;
                         break;


### PR DESCRIPTION
Hello, great job continuing to enhance the vCard repo allowing so much reach with a simple file.

After using a simple vCard script for 5 years it is time for an upgrade after reviewing additional properties and functions I found $this repo. Here are 2 suggestions:

1. Adding a **Social Media** option, this will allow twitter, flickr, linkedin, etc... to be listed in the vCard

2. Change the property type for **setProperty** from private to protected which would allow the ability to extend the class with custom functionality while maintaining the ability to use PHP Composer.

There are a few updates I'd list to submit if this request it approved. Several "type field" options which could be improved, more on this later. Thanks!

[vCard for Jason Gegere](https://gege.re/vcard/)

