### PR TITLE
Fix content-length header for vcards with multibyte encodings

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -752,7 +752,7 @@ class VCard
     {
         $contentType = $this->getContentType() . '; charset=' . $this->getCharset();
         $contentDisposition = 'attachment; filename=' . $this->getFilename() . '.' . $this->getFileExtension();
-        $contentLength = mb_strlen($this->getOutput(), $this->getCharset());
+        $contentLength = mb_strlen($this->getOutput(), '8bit');
         $connection = 'close';
 
         if ((bool)$asAssociative) {


### PR DESCRIPTION
The Content-Length header must be the [_the size of the entity-body, in decimal number of OCTETs_](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13).

From the `mb_strlen` php docs: [A multi-byte character is counted as 1](http://php.net/manual/en/function.mb-strlen.php).
This means that `mb_strlen($this->getOutput(), 'utf-8');` can not be counted on to get the correct content-length when calling `$vcard->download()` if you have multibyte strings.

An alternative could be to use `strlen` as it [returns the number of bytes rather than the number of characters in a string](http://php.net/manual/en/function.strlen.php).
That being said, `strlen` is still not safe because it can be overloaded in `php.ini` with [mbstring.func_overload](http://php.net/manual/en/mbstring.overload.php)

Both PR #89 and #93 have addressed this, but in different ways. As far as I can see none of them have been merged.

I think the safest choice would be to use mb_strlen with 8bit as encoding as this will force the content-length in octets.


Example when `mb_strlen($this->getOutput(), $this->getCharset())` (v1.7.1) will fail with charset utf-8:
```
$vcard = new VCard();
$vcard->addName('Åge Ågesen');
....
return $vcard->download();
```
The downloaded file look like this:
```
BEGIN:VCARD
VERSION:3.0
REV:2019-02-27T21:50:05Z
N;CHARSET=utf-8:Åge Ågesen;;;;
FN;CHARSET=utf-8:Åge Ågesen
EMAIL;INTERNET;WORK:age@test.com
TEL;WORK:12345678
PHOTO;ENCODING=b;TYPE=JPEG:/9j/4AAQSkZJRgABAQEBLAEsAAD/4gGoSUNDX1BST0ZJTEUA
 ...
 8oPsm0cqiQ54WPqH7QWjjKqt0O+YZ6ALMMIw492+6jk7sn9Vbk4jwoplwe6/9k=
ORG;CHARSET=utf-8:myComp
TITLE;CHARSET=utf-8:
END:VCA
```
Note the missing ending of the file because of wrong content-length.
After the change in this PR the file will be the correct content-length and the whole file will be downloaded.