### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,25 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.4
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
   - hhvm
 
 sudo: false
 
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-source --no-interaction
 
 script:
-  - phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-text
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,16 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "behat/transliterator": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.6.*"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": { "JeroenDesloovere\\VCard\\": "src/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "JeroenDesloovere\\VCard\\": "tests/" }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-        bootstrap="vendor/autoload.php"
+        bootstrap="./vendor/autoload.php"
         colors="true"
         verbose="true">
     <testsuites>

--- a/tests/VCardExceptionTest.php
+++ b/tests/VCardExceptionTest.php
@@ -2,8 +2,7 @@
 
 namespace JeroenDesloovere\VCard;
 
-// required to load
-require_once __DIR__ . '/../vendor/autoload.php';
+use PHPUnit\Framework\TestCase;
 
 /*
  * This file is part of the VCard PHP Class from Jeroen Desloovere.
@@ -15,7 +14,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 /**
  * VCard Exception Test.
  */
-class VCardExceptionTest extends \PHPUnit_Framework_TestCase
+class VCardExceptionTest extends TestCase
 {
     /**
      * @expectedException JeroenDesloovere\VCard\VCardException

--- a/tests/VCardParserTest.php
+++ b/tests/VCardParserTest.php
@@ -4,11 +4,12 @@ namespace JeroenDesloovere\VCard\tests;
 
 use JeroenDesloovere\VCard\VCard;
 use JeroenDesloovere\VCard\VCardParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for our VCard parser.
  */
-class VCardParserTest extends \PHPUnit_Framework_TestCase
+class VCardParserTest extends TestCase
 {
     /**
      * @expectedException OutOfBoundsException

--- a/tests/VCardTest.php
+++ b/tests/VCardTest.php
@@ -2,9 +2,6 @@
 
 namespace JeroenDesloovere\VCard\tests;
 
-// required to load
-require_once __DIR__ . '/../vendor/autoload.php';
-
 /*
  * This file is part of the VCard PHP Class from Jeroen Desloovere.
  *
@@ -13,11 +10,12 @@ require_once __DIR__ . '/../vendor/autoload.php';
  */
 
 use JeroenDesloovere\VCard\VCard;
+use PHPUnit\Framework\TestCase;
 
 /**
  * This class will test our VCard PHP Class which can generate VCards.
  */
-class VCardTest extends \PHPUnit_Framework_TestCase
+class VCardTest extends TestCase
 {
     /**
      * @var VCard
@@ -44,7 +42,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         // set timezone
         date_default_timezone_set('Europe/Brussels');
@@ -56,7 +54,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
         $this->additional = '&';
         $this->prefix = 'Mister';
         $this->suffix = 'Junior';
-        
+
         $this->emailAddress1 = '';
         $this->emailAddress2 = '';
 
@@ -70,7 +68,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
     /**
      * Tear down after class
      */
-    public function tearDown()
+    protected function tearDown()
     {
         $this->vcard = null;
     }
@@ -137,7 +135,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($this->vcard, $this->vcard->addPhoneNumber(''));
         $this->assertEquals($this->vcard, $this->vcard->addPhoneNumber(''));
-        $this->assertEquals(2, count($this->vcard->getProperties()));
+        $this->assertCount(2, $this->vcard->getProperties());
     }
 
     public function testAddPhotoWithJpgPhoto()
@@ -225,7 +223,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($this->vcard, $this->vcard->addUrl('1'));
         $this->assertEquals($this->vcard, $this->vcard->addUrl('2'));
-        $this->assertEquals(2, count($this->vcard->getProperties()));
+        $this->assertCount(2, $this->vcard->getProperties());
     }
 
     /**
@@ -445,7 +443,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame($this->vcard, $this->vcard->addLabel('My label'));
         $this->assertSame($this->vcard, $this->vcard->addLabel('My work label', 'WORK'));
-        $this->assertSame(2, count($this->vcard->getProperties()));
+        $this->assertCount(2, $this->vcard->getProperties());
         $this->assertContains('LABEL:My label', $this->vcard->getOutput());
         $this->assertContains('LABEL;WORK:My work label', $this->vcard->getOutput());
     }


### PR DESCRIPTION
# Changed log
- The Travis CI build uses `xenial` dist by default and this dist doesn't include `php-5.4` and `php-5.5` versions.
To resolve this, add `trusty` dist instead on Travis CI build.
- Add `php-7.1`, `php-7.2` and `php-7.3` versions on Travis CI build.
- The `--dev` option is deprecated on `composer`. Removing this.
- Defining the final `PHPUnit 4.8.36` version to be compatible with future PHPUnit versions.
Using the `PHPUnit\Framework\TestCase` to be easy to migrate to future stable `PHPUnit` version.
- It seems that the `php-5.3` is too old and I think it's proper to let this package require `php-5.4` version at least.
- Adding the `autoload-dev` to load test classes automatically.