### PR TITLE
Make `setProperty` public to specify custom properties

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -935,7 +935,7 @@ class VCard
      * @param  string $value
      * @throws VCardException
      */
-    private function setProperty($element, $key, $value)
+    public function setProperty($element, $key, $value)
     {
         if (!in_array($element, $this->multiplePropertiesForElementAllowed)
             && isset($this->definedElements[$element])


### PR DESCRIPTION
It should be possible to set any properties you need to. For example, the "fullname" ("FN") property is automatically set and to customize the full name, `setProperty` needs to be public.