### PR TITLE
Add optional argument to addName() to set FN

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -325,6 +325,7 @@ class VCard
      * @param  string [optional] $additional
      * @param  string [optional] $prefix
      * @param  string [optional] $suffix
+     * @param  string [optional] $fullName
      * @return $this
      */
     public function addName(
@@ -332,19 +333,26 @@ class VCard
         $firstName = '',
         $additional = '',
         $prefix = '',
-        $suffix = ''
+        $suffix = '',
+        $fullName = ''
     ) {
-        // define values with non-empty values
-        $values = array_filter([
-            $prefix,
-            $firstName,
-            $additional,
-            $lastName,
-            $suffix,
-        ]);
 
-        // define filename
-        $this->setFilename($values);
+        if ($fullName === '') {
+            // define values with non-empty values
+            $values = array_filter([
+                $prefix,
+                $firstName,
+                $additional,
+                $lastName,
+                $suffix,
+            ]);
+            // define filename
+            $this->setFilename($values);
+
+            $fullName = trim(implode(' ', $values));
+        } else {
+            $this->setFilename($fullName);
+        }
 
         // set property
         $property = $lastName . ';' . $firstName . ';' . $additional . ';' . $prefix . ';' . $suffix;
@@ -360,7 +368,7 @@ class VCard
             $this->setProperty(
                 'fullname',
                 'FN' . $this->getCharsetString(),
-                trim(implode(' ', $values))
+                $fullName
             );
         }
 
@@ -643,7 +651,7 @@ class VCard
     /**
      * multibyte word chunk split
      * @link http://php.net/manual/en/function.chunk-split.php#107711
-     * 
+     *
      * @param  string  $body     The string to be chunked.
      * @param  integer $chunklen The chunk length.
      * @param  string  $end      The line ending sequence.

--- a/tests/VCardTest.php
+++ b/tests/VCardTest.php
@@ -56,7 +56,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
         $this->additional = '&';
         $this->prefix = 'Mister';
         $this->suffix = 'Junior';
-        
+
         $this->emailAddress1 = '';
         $this->emailAddress2 = '';
 
@@ -65,6 +65,10 @@ class VCardTest extends \PHPUnit_Framework_TestCase
 
         $this->firstName3 = 'Garçon';
         $this->lastName3 = 'Jéroèn';
+
+        $this->firstName4 = '潤發';
+        $this->lastName4 = '周';
+        $this->fullName4 = '周潤發';
     }
 
     /**
@@ -127,6 +131,29 @@ class VCardTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($this->vcard, $this->vcard->addName(''));
     }
+
+
+    /**
+     * Test addName with fullname
+     */
+    public function testAddNameWithFullName()
+    {
+        $return = $this->vcard->addName(
+            $this->lastName4,
+            $this->firstName4,
+            '',
+            '',
+            '',
+            $this->fullName4
+        );
+
+        $this->assertEquals($this->vcard, $return);
+
+        $this->assertContains($this->fullName4, $this->vcard->getOutput());
+        $this->assertEquals('zhou-run-fa', $this->vcard->getFilename());
+    }
+
+
 
     public function testAddNote()
     {
@@ -334,6 +361,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('mister-jeroen-desloovere-junior', $this->vcard->getFilename());
     }
+
 
     /**
      * Test multiple birthdays


### PR DESCRIPTION
Not all language concatenate the fullname using the format "Prefix Firstname Additonal Lastname Suffix". Chinese names for example uses the format "LastnameFirstname". This request allows the user to optionally pass in an argument to set the FN property.