### PR TITLE
php 8.1 deprecation fix

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -669,6 +669,10 @@ class VCard
      */
     protected function escape($text)
     {
+        if ($text === null) {
+            return '';
+        }
+
         $text = str_replace("\r\n", "\\n", $text);
         $text = str_replace("\n", "\\n", $text);
 


### PR DESCRIPTION
Fixes "str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /vendor/jeroendesloovere/vcard/src/VCard.php on line 672"