### PR TITLE
Fix \mb_convert_encoding error handling

### DIFF
--- a/src/VCardParser.php
+++ b/src/VCardParser.php
@@ -189,7 +189,7 @@ class VCardParser implements Iterator
                     } elseif (strpos(strtolower($type), 'charset=') === 0) {
                         try {
                             $value = mb_convert_encoding($value, "UTF-8", substr($type, 8));
-                        } catch (\Exception $e) {
+                        } catch (\Throwable $e) {
                         }
                         unset($types[$i]);
                     }

--- a/tests/VCardParserTest.php
+++ b/tests/VCardParserTest.php
@@ -292,4 +292,14 @@ class VCardParserTest extends TestCase
         $parser = new VCardParser($vcard->buildVCard());
         $this->assertEquals($parser->getCardAtIndex(0)->label, $label);
     }
+
+    public function testInvalidEndingConversion()
+    {
+        $parser = VCardParser::parseFromFile(__DIR__ . '/invalid_encoding.vcf');
+
+        $cards = $parser->getCards();
+
+        $this->assertEquals($cards[0]->firstname, 'Jeroen');
+        $this->assertEquals($cards[0]->lastname, 'Desloovere');
+    }
 }

--- a/tests/invalid_encoding.vcf
+++ b/tests/invalid_encoding.vcf
@@ -1,0 +1,10 @@
+BEGIN:VCARD
+VERSION:3.0
+REV:2016-05-30T10:36:13Z
+N;CHARSET=invalid-encoding:Desloovere;Jeroen;;;
+FN;CHARSET=utf-8:Jeroen Desloovere
+item1.EMAIL;type=INTERNET:site@example.com
+item1.X-ABLabel:$!<Email>!$
+item2.URL:http://www.jeroendesloovere.be
+item2.X-ABLabel:$!<Home>!$
+END:VCARD


### PR DESCRIPTION
Error thrown during converting value encoding from specified in VCF file to UTF-8 should be caught, but it is not, becouse since PHP 8.0.0 `\mb_convert_encoding()` will throw `\ValueError` (as mentioned in [mb-convert-encoding-changelog](https://www.php.net/manual/en/function.mb-convert-encoding.php#refsect1-function.mb-convert-encoding-changelog)) which inherits from `\Error`, which inherits directly from `\Throwable`, not `\Exception` which `VCardParser` is curently catching.

Currently VCF:
```
BEGIN:VCARD
...
N;CHARSET=windows-1250:Jacobsen;Thies-Tillman;;;
...
```
will throw error: `mb_convert_encoding(): Argument #3 ($from_encoding) contains invalid encoding "windows-1250"`
which is not handled
