### PR TITLE
Fix invalid folding

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -528,7 +528,7 @@ class VCard
         $properties = $this->getProperties();
         foreach ($properties as $property) {
             // add to string
-            $string .= $this->fold($property['key'] . ':' . $this->escape($property['value']) . "\r\n");
+            $string .= $this->fold($property['key'] . ':' . $this->escape($property['value'])) . "\r\n";
         }
 
         // add to string


### PR DESCRIPTION
I had the (bad)luck to get `"\r\n"` cut into two lines.
So it came with strange result (invalid VCF):

```
\r
\r
\n 
\n
```
""