### PR TITLE
Modifying convertEmptyStringToNull function to pass variables by reference

### DIFF
--- a/src/Parser/Property/AddressParser.php
+++ b/src/Parser/Property/AddressParser.php
@@ -33,7 +33,7 @@ final class AddressParser extends PropertyParser implements NodeParserInterface
             $countryName
         ) = explode(';', $value);
 
-        $this->convertEmptyStringToNull([
+        $this->convertEmptyStringToNull(
             $postOfficeBox,
             $extendedAddress,
             $streetAddress,
@@ -41,7 +41,7 @@ final class AddressParser extends PropertyParser implements NodeParserInterface
             $region,
             $postalCode,
             $countryName
-        ]);
+        );
 
         return new Address($postOfficeBox, $extendedAddress, $streetAddress, $locality, $region, $postalCode, $countryName);
     }

--- a/src/Parser/Property/GenderParser.php
+++ b/src/Parser/Property/GenderParser.php
@@ -13,7 +13,7 @@ final class GenderParser extends PropertyParser implements NodeParserInterface
     {
         @list($gender, $note) = explode(';', $value, 2);
 
-        $this->convertEmptyStringToNull([$note]);
+        $this->convertEmptyStringToNull($note);
 
         return new Gender($gender, $note);
     }

--- a/src/Parser/Property/NameParser.php
+++ b/src/Parser/Property/NameParser.php
@@ -13,13 +13,13 @@ final class NameParser extends PropertyParser implements NodeParserInterface
     {
         @list($firstName, $additional, $lastName, $prefix, $suffix) = explode(';', $value);
 
-        $this->convertEmptyStringToNull([
+        $this->convertEmptyStringToNull(
             $lastName,
             $firstName,
             $additional,
             $prefix,
             $suffix
-        ]);
+        );
 
         return new Name($lastName, $firstName, $additional, $prefix, $suffix);
     }

--- a/src/Parser/Property/PropertyParser.php
+++ b/src/Parser/Property/PropertyParser.php
@@ -6,7 +6,7 @@ namespace JeroenDesloovere\VCard\Parser\Property;
 
 class PropertyParser
 {
-    protected function convertEmptyStringToNull(array $values): void
+    protected function convertEmptyStringToNull(&...$values): void
     {
         foreach ($values as &$value) {
             if ($value === '') {


### PR DESCRIPTION
Good morning,

I noticed that the convertEmptyStringToNull function in your code was not working as expected when handling variables like $lastName, $firstName, etc. The reason is that these variables are passed by value in an array to the function, so changes made in the function are not reflected in the original variables.
Issue :

The current function takes an array of values and tries to replace empty strings with null. However, since the variables are passed by value, the changes are not applied to the original variables outside the function.
Proposed solution :

Modify the function to accept a variable number of arguments per reference. So any changes made to these variables within the function will reflect on the variables themselves.

Here is the modified code:

```php
protected function convertEmptyStringToNull(&...$values): void
{
    foreach ($values as &$value) {
        if ($value === '') {
            $value = null;
        }
    }
}

```

And its use:
```php

$this->convertEmptyStringToNull($lastName, $firstName, $additional, $prefix, $suffix);

```
Benefits of this change:
- Increased flexibility: The function can now directly manipulate passed variables, making it more flexible and powerful.
- Intuitive behavior: This modification makes the behavior of the function more intuitive and consistent with user expectations.
- Ease of use: Users no longer need to create an array to pass variables to the function.

I think this change could benefit the robustness and usefulness of your library. I look forward to your feedback and am open to any further discussion or changes if necessary.

Thank you for your time and consideration.

Sincerely,