### PR TITLE
Fix order of elements in `NameParser::parseVcfString`

### DIFF
--- a/src/Parser/Property/NameParser.php
+++ b/src/Parser/Property/NameParser.php
@@ -11,7 +11,7 @@ final class NameParser extends PropertyParser implements NodeParserInterface
 {
     public function parseVcfString(string $value, array $parameters = []): NodeInterface
     {
-        @list($firstName, $additional, $lastName, $prefix, $suffix) = explode(';', $value);
+        @list($lastName, $firstName, $additional, $prefix, $suffix) = explode(';', $value);
 
         $this->convertEmptyStringToNull([
             $lastName,


### PR DESCRIPTION
Hello,

I noticed an issue in the `parseVcfString` method of the `NameParser` class, where the order of elements extracted from the VCF string does not match the expected fields for the `Name` object. In particular, the positions of the firstName and additional information seem to be reversed.

### Problem observed:

In the current code, the VCF string is split into segments with `explode`, but the segments are assigned to variables in the wrong order. For example, for a VCF line like `N:DUPONT;Thierry;;;`, the first name and additional information are reversed.

### Proposed solution :

Change the order of variables in the list assignment to correctly reflect the structure of the VCF string. Thus, `$firstName` receives the first name and `$additional` receives the additional information, according to the VCF specification.

Here is the corrected code:
```php
final class NameParser extends PropertyParser implements NodeParserInterface
{
    public function parseVcfString(string $value, array $parameters = []): NodeInterface
    {
        @list($firstName, $lastName, $additional, $prefix, $suffix) = explode(';', $value);

        $this->convertEmptyStringToNull([
            $lastName,
            $firstName,
            $additional,
            $prefix,
            $suffix
        ]);

        return new Name($lastName, $firstName, $additional, $prefix, $suffix);
    }
}
```


Thank you for your time and consideration.