### PR TITLE
Massive VCF Import – Thrown problematic

### DIFF
--- a/src/Property/Parameter/Type.php
+++ b/src/Property/Parameter/Type.php
@@ -30,7 +30,7 @@ final class Type implements PropertyParameterInterface, SimpleNodeInterface
     public function __construct(string $value)
     {
         if (!in_array($value, self::POSSIBLE_VALUES, true)) {
-            throw PropertyParameterException::forWrongValue($value, self::POSSIBLE_VALUES);
+            $value = self::HOME;
         }
 
         $this->value = $value;

--- a/src/VCard.php
+++ b/src/VCard.php
@@ -120,19 +120,18 @@ final class VCard
 
     /**
      * @param PropertyParameterInterface $propertyParameter
-     * @throws VCardException
      */
     private function addPropertyParameter(PropertyParameterInterface $propertyParameter): void
     {
         // Parameter is not allowed multiple times
         if ($this->hasParameter(get_class($propertyParameter))) {
-            throw VCardException::forExistingPropertyParameter($propertyParameter);
+            return;
         }
 
         $this->parameters[] = $propertyParameter;
     }
 
-    public function getKind(): Kind
+    public function getKind()
     {
         $kind = $this->getParameters(Kind::class);
 


### PR DESCRIPTION
Hello,

During a massive import, I noticed a fairly significant loss of data, particularly on telephone numbers which did not have the right type. Example, on an old VCF file extracted from an IMAP, I have lines that look like:
`TEL;TYPE=CELL:06 00 00 00 34`

And `CELL` is not part of the authorized category, so because of the Thrown, the data is lost on import

I suggest removing these Thrown (ultimately, maybe put a logger to recover the bad data?)

Same for Thrown classes already used, I suggest removing them and exiting the function without stopping everything

Thank you for your time and consideration.