### PR TITLE
Improved formatting of telephone numbers according to the RFC3966 standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,11 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "brick/phonenumber": "^0.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.2",
         "mikey179/vfsstream": "^1.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": ">=7.1",
-        "brick/phonenumber": "^0.6.0"
+        "brick/phonenumber": "^0.6.0",
+        "ext-intl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",

--- a/src/Formatter/Property/TelephoneFormatter.php
+++ b/src/Formatter/Property/TelephoneFormatter.php
@@ -20,6 +20,6 @@ final class TelephoneFormatter implements NodeFormatterInterface
     {
         return $this->telephone->getNode() .
           ';TYPE=' . $this->telephone->getType()->__toString() .
-          ';VALUE=' . $this->telephone->getValue() . ':tel:' . $this->telephone->getTelephoneNumber();
+          ';VALUE=' . $this->telephone->getValue() . ':' . $this->telephone->getTelephoneNumberURI();
     }
 }

--- a/src/Property/Telephone.php
+++ b/src/Property/Telephone.php
@@ -29,8 +29,8 @@ final class Telephone implements PropertyInterface, NodeInterface
 
     public function __construct(string $telephoneNumber, Type $type = null, Value $value = null)
     {
-
-        $this->phoneNumber = PhoneNumber::parse($telephoneNumber);
+        $regionCode = \Locale::getRegion(\Locale::getDefault());
+        $this->phoneNumber = PhoneNumber::parse($telephoneNumber, $regionCode);
         $this->telephoneNumber = $this->phoneNumber->format(PhoneNumberFormat::NATIONAL);
 
         $this->type = $type ?? Type::home();

--- a/src/Property/Telephone.php
+++ b/src/Property/Telephone.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace JeroenDesloovere\VCard\Property;
 
+use Brick\PhoneNumber\PhoneNumber;
+use Brick\PhoneNumber\PhoneNumberFormat;
 use JeroenDesloovere\VCard\Formatter\Property\NodeFormatterInterface;
 use JeroenDesloovere\VCard\Formatter\Property\TelephoneFormatter;
 use JeroenDesloovere\VCard\Parser\Property\NodeParserInterface;
@@ -16,6 +18,9 @@ final class Telephone implements PropertyInterface, NodeInterface
     /** @var string */
     protected $telephoneNumber;
 
+    /** @var PhoneNumber */
+    protected $phoneNumber;
+
     /** @var Type */
     private $type;
 
@@ -24,7 +29,10 @@ final class Telephone implements PropertyInterface, NodeInterface
 
     public function __construct(string $telephoneNumber, Type $type = null, Value $value = null)
     {
-        $this->telephoneNumber = str_replace(' ', '-', $telephoneNumber);
+
+        $this->phoneNumber = PhoneNumber::parse($telephoneNumber);
+        $this->telephoneNumber = $this->phoneNumber->format(PhoneNumberFormat::NATIONAL);
+
         $this->type = $type ?? Type::home();
         $this->value = $value ?? Value::uri();
     }
@@ -47,6 +55,16 @@ final class Telephone implements PropertyInterface, NodeInterface
     public function getTelephoneNumber(): string
     {
         return $this->telephoneNumber;
+    }
+
+    public function getTelephoneNumberURI(): string
+    {
+        return $this->phoneNumber->format(PhoneNumberFormat::RFC3966);
+    }
+
+    public function getPhoneNumber(): PhoneNumber
+    {
+        return $this->phoneNumber;
     }
 
     public static function getParser(): NodeParserInterface


### PR DESCRIPTION
Hello,

I propose a significant improvement in the management of telephone numbers within your library. This enhancement aims to standardize phone number formatting based on the RFC3966 standard for phone number URIs. This will enable more consistent and standardized management of phone numbers, regardless of their original format.

### Motivation :

The diversity of telephone number formats and the need to handle them in a uniform manner that complies with international standards underlines the importance of this update. Using the library [brick/phonenumber](https://github.com/brick/phonenumber), which is a wrapper around [giggsey/libphonenumber-for-php](https://github.com/giggsey/libphonenumber -for-php), we can ensure efficient and robust standardization of phone numbers.

### Proposed changes:

1. **Updated `composer.json`** to include `brick/phonenumber` as a dependency, ensuring that phone number manipulation is done with a dedicated and powerful tool.
2. **Modified `TelephoneFormatter.php`** to use RFC3966-compliant URI format when outputting phone numbers.
3. **Added parsing and formatting logic to `Telephone.php`** to transform incoming phone numbers into their standardized representation, and to support formatting according to the region defined on the server.


### Benefits :

- **Conformity:** All phone numbers will be formatted consistently.
- **Compliance with standards:** The adoption of the RFC3966 standard improves compatibility and interoperability.
- **Flexibility:** Formatting takes into account the region defined on the server, allowing automatic adaptation to local conventions.

I firmly believe that these changes will add significant value to your library by simplifying phone number management for end users. I look forward to your comments and am open to any discussion to refine this proposal.

Thanks for your consideration.

