### PR TITLE
Escape comma with backslash

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -975,6 +975,9 @@ class VCard
         // we define that we set this element
         $this->definedElements[$element] = true;
 
+        // Commas must be escaped with a backslash.
+        $value = str_replace(',', '\,', $value);
+
         // adding property
         $this->properties[] = [
             'key' => $key,


### PR DESCRIPTION
Without this, values containing a comma will cause an error in some parsers.